### PR TITLE
Reintroduce Image to the CR

### DIFF
--- a/apicurito/build/conf/config_test.yaml
+++ b/apicurito/build/conf/config_test.yaml
@@ -1,0 +1,1 @@
+Image: "apicurio/apicurito-ui"

--- a/apicurito/deploy/crds/apicur_v1alpha1_apicurito_cr.yaml
+++ b/apicurito/deploy/crds/apicur_v1alpha1_apicurito_cr.yaml
@@ -5,4 +5,3 @@ metadata:
 spec:
   # Add fields here
   size: 3
-  image: apicurio/apicurito-ui:latest

--- a/apicurito/deploy/operator.yaml
+++ b/apicurito/deploy/operator.yaml
@@ -18,8 +18,6 @@ spec:
       containers:
         - name: apicurito-operator
           image: apicurio/apicurito-operator:v0.1
-          command:
-          - apicurito
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/apicurito/go.mod
+++ b/apicurito/go.mod
@@ -20,8 +20,9 @@ require (
 	github.com/googleapis/gnostic v0.0.0-20180519185700-7c663266750e // indirect
 	github.com/gophercloud/gophercloud v0.0.0-20190423165001-666dacaccf07 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc // indirect
-	github.com/imdario/mergo v0.0.0-20190123232827-7c29201646fa // indirect
+	github.com/imdario/mergo v0.0.0-20190123232827-7c29201646fa
 	github.com/inconshreveable/mousetrap v0.0.0-20141017200713-76626ae9c91c // indirect
+	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/json-iterator/go v0.0.0-20190306142909-0ff49de124c6 // indirect
 	github.com/mailru/easyjson v0.0.0-20190403194419-1ea4449da983 // indirect
 	github.com/markbates/inflect v0.0.0-20181024203500-24b83195037b // indirect

--- a/apicurito/go.sum
+++ b/apicurito/go.sum
@@ -98,6 +98,8 @@ github.com/imdario/mergo v0.0.0-20190123232827-7c29201646fa h1:8KA1k2BWIE5weO1h1
 github.com/imdario/mergo v0.0.0-20190123232827-7c29201646fa/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v0.0.0-20141017200713-76626ae9c91c h1:Ur2o+2uZgGSejDFvjNQwiKVey0RCq6PjxK+WIDeRik8=
 github.com/inconshreveable/mousetrap v0.0.0-20141017200713-76626ae9c91c/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a h1:zPPuIq2jAWWPTrGt70eK/BSch+gFAGrNzecsoENgu2o=
+github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a/go.mod h1:yL958EeXv8Ylng6IfnvG4oflryUi3vgA3xPs9hmII1s=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/json-iterator/go v0.0.0-20190306142909-0ff49de124c6 h1:dD4LaEjgkIC47F/YBxH/93ZfKvWHKvgFmpgsI6KCkhs=

--- a/apicurito/pkg/apis/apicur/v1alpha1/apicurito_types.go
+++ b/apicurito/pkg/apis/apicur/v1alpha1/apicurito_types.go
@@ -14,6 +14,9 @@ type ApicuritoSpec struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
 	Size int32 `json:"size"`
+
+	// +kubebuilder:validation:Pattern=.+:.+
+	Image string `json:"image"`
 }
 
 // ApicuritoStatus defines the observed state of Apicurito

--- a/apicurito/pkg/controller/apicurito/apicurito_controller.go
+++ b/apicurito/pkg/controller/apicurito/apicurito_controller.go
@@ -5,9 +5,9 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/apicurio/apicurio-operators/apicurito/pkg/properties"
+	"github.com/apicurio/apicurio-operators/apicurito/pkg/apis/apicur/v1alpha1"
 
-	apicuritosv1alpha1 "github.com/apicurio/apicurio-operators/apicurito/pkg/apis/apicur/v1alpha1"
+	"github.com/apicurio/apicurio-operators/apicurito/pkg/properties"
 
 	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -56,7 +56,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to primary resource Apicurito
-	err = c.Watch(&source.Kind{Type: &apicuritosv1alpha1.Apicurito{}}, &handler.EnqueueRequestForObject{})
+	err = c.Watch(&source.Kind{Type: &v1alpha1.Apicurito{}}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		return err
 	}
@@ -65,7 +65,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Watch for changes to secondary resource Pods and requeue the owner Apicurito
 	err = c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
-		OwnerType:    &apicuritosv1alpha1.Apicurito{},
+		OwnerType:    &v1alpha1.Apicurito{},
 	})
 	if err != nil {
 		return err
@@ -94,7 +94,7 @@ func (r *ReconcileApicurito) Reconcile(request reconcile.Request) (reconcile.Res
 	reqLogger.Info("Reconciling Apicurito.")
 
 	// Fetch the Apicurito instance
-	apicurito := &apicuritosv1alpha1.Apicurito{}
+	apicurito := &v1alpha1.Apicurito{}
 	err := r.client.Get(context.TODO(), request.NamespacedName, apicurito)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -210,8 +210,8 @@ func (r *ReconcileApicurito) Reconcile(request reconcile.Request) (reconcile.Res
 }
 
 // deploymentForApicurito returns a apicurito Deployment object
-func (r *ReconcileApicurito) deploymentForApicurito(m *apicuritosv1alpha1.Apicurito) (*appsv1.Deployment, error) {
-	p, err := properties.GetProperties()
+func (r *ReconcileApicurito) deploymentForApicurito(m *v1alpha1.Apicurito) (*appsv1.Deployment, error) {
+	p, err := properties.GetProperties(m)
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +285,7 @@ func labelsForApicurito(name string) map[string]string {
 }
 
 // serviceForApicurito returns an apicurito Service
-func (r *ReconcileApicurito) serviceForApicurito(a *apicuritosv1alpha1.Apicurito) *corev1.Service {
+func (r *ReconcileApicurito) serviceForApicurito(a *v1alpha1.Apicurito) *corev1.Service {
 	ls := labelsForApicurito(a.Name)
 
 	service := &corev1.Service{
@@ -313,7 +313,7 @@ func (r *ReconcileApicurito) serviceForApicurito(a *apicuritosv1alpha1.Apicurito
 	return service
 }
 
-func (r *ReconcileApicurito) routeForApicurito(a *apicuritosv1alpha1.Apicurito) *routev1.Route {
+func (r *ReconcileApicurito) routeForApicurito(a *v1alpha1.Apicurito) *routev1.Route {
 	ls := labelsForApicurito(a.Name)
 	route := routev1.Route{
 		TypeMeta: metav1.TypeMeta{
@@ -326,8 +326,8 @@ func (r *ReconcileApicurito) routeForApicurito(a *apicuritosv1alpha1.Apicurito) 
 			Labels:    ls,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(a, schema.GroupVersionKind{
-					Group:   apicuritosv1alpha1.SchemeGroupVersion.Group,
-					Version: apicuritosv1alpha1.SchemeGroupVersion.Version,
+					Group:   v1alpha1.SchemeGroupVersion.Group,
+					Version: v1alpha1.SchemeGroupVersion.Version,
 					Kind:    a.Kind,
 				}),
 			},

--- a/apicurito/pkg/properties/properties.go
+++ b/apicurito/pkg/properties/properties.go
@@ -17,47 +17,89 @@
 package properties
 
 import (
-    "encoding/json"
-    "github.com/apicurio/apicurio-operators/apicurito/pkg/configuration"
-    "io/ioutil"
-    "k8s.io/apimachinery/pkg/util/yaml"
-    "strings"
+	"encoding/json"
+	"io/ioutil"
+	"strings"
+
+	"github.com/imdario/mergo"
+
+	"github.com/apicurio/apicurio-operators/apicurito/pkg/apis/apicur/v1alpha1"
+	"github.com/apicurio/apicurio-operators/apicurito/pkg/configuration"
+	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 type Properties struct {
-    Image string
+	Image string
 }
 
 // Returns all processed properties for Apicurito
-func GetProperties() (*Properties, error) {
-    c := configuration.GetConfiguration()
-    p, err := loadFromFile(c.ConfigFile)
-    if err != nil {
-        return nil, err
-    }
+func GetProperties(apicurito *v1alpha1.Apicurito) (*Properties, error) {
+	c := configuration.GetConfiguration()
+	cp, err := loadFromFile(c.ConfigFile)
+	if err != nil {
+		return nil, err
+	}
 
-    return p, nil
+	ap, err := loadFromApicurito(apicurito)
+	if err != nil {
+		return nil, err
+	}
+
+	rp, err := mergeProperties(*cp, *ap)
+	if err != nil {
+		return nil, err
+	}
+
+	return rp, nil
 }
 
 // Load configuration from config file. Config file is expected to be a yaml
 // The returned configuration is parsed to JSON and returned as Properties
-func loadFromFile(config string ) (*Properties, error) {
-    data, err := ioutil.ReadFile(config)
-    if err != nil {
-        return nil, err
-    }
+func loadFromFile(config string) (*Properties, error) {
+	data, err := ioutil.ReadFile(config)
+	if err != nil {
+		return nil, err
+	}
 
-    if strings.HasSuffix(config, ".yaml") || strings.HasSuffix(config, ".yml") {
-        data, err = yaml.ToJSON(data)
-        if err != nil {
-            return nil, err
-        }
-    }
+	if strings.HasSuffix(config, ".yaml") || strings.HasSuffix(config, ".yml") {
+		data, err = yaml.ToJSON(data)
+		if err != nil {
+			return nil, err
+		}
+	}
 
-    p := &Properties{}
-    if err := json.Unmarshal(data, p); err != nil {
-        return nil, err
-    }
+	p := &Properties{}
+	if err := json.Unmarshal(data, p); err != nil {
+		return nil, err
+	}
 
-    return p, nil
+	return p, nil
+}
+
+// From apicurito CR, Unmarshal it into a property object
+func loadFromApicurito(apicurito *v1alpha1.Apicurito) (*Properties, error) {
+	p := &Properties{}
+
+	jsonProperties, err := json.Marshal(apicurito.Spec)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(jsonProperties, p)
+	if err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+// Merge two Property objectsand owerwrite config values with apicurito values
+// if the fields in apicurito arent set to its 0 value.
+func mergeProperties(config Properties, apicurito Properties) (*Properties, error) {
+	err := mergo.Merge(&config, apicurito, mergo.WithOverride)
+	if err != nil {
+		return nil, err
+	}
+
+	return &config, nil
 }

--- a/apicurito/pkg/properties/properties.go
+++ b/apicurito/pkg/properties/properties.go
@@ -93,8 +93,8 @@ func loadFromApicurito(apicurito *v1alpha1.Apicurito) (*Properties, error) {
 	return p, nil
 }
 
-// Merge two Property objectsand owerwrite config values with apicurito values
-// if the fields in apicurito arent set to its 0 value.
+// Merge two Property objects and overwrite config values with apicurito values
+// if the fields in apicurito aren't set to its 0 value.
 func mergeProperties(config Properties, apicurito Properties) (*Properties, error) {
 	err := mergo.Merge(&config, apicurito, mergo.WithOverride)
 	if err != nil {

--- a/apicurito/pkg/properties/properties_test.go
+++ b/apicurito/pkg/properties/properties_test.go
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package properties
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/apicurio/apicurio-operators/apicurito/pkg/apis/apicur/v1alpha1"
+)
+
+func TestGetProperties(t *testing.T) {
+	type args struct {
+		apicurito *v1alpha1.Apicurito
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *Properties
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetProperties(tt.args.apicurito)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetProperties() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetProperties() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_loadFromApicurito(t *testing.T) {
+	type args struct {
+		apicurito *v1alpha1.Apicurito
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *Properties
+		wantErr bool
+	}{
+		{
+			"When reading from apicurito, all fields should be loaded",
+			args{&v1alpha1.Apicurito{Spec: v1alpha1.ApicuritoSpec{Image: "apicurio/apicurito-ui"}}},
+			&Properties{Image: "apicurio/apicurito-ui"},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := loadFromApicurito(tt.args.apicurito)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("loadFromApicurito() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("loadFromApicurito() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_loadFromFile(t *testing.T) {
+	type args struct {
+		config string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *Properties
+		wantErr bool
+	}{
+		{
+			"When loading a config file, all parameter should match",
+			args{config: "../../build/conf/config_test.yaml"},
+			&Properties{Image: "apicurio/apicurito-ui"},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := loadFromFile(tt.args.config)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("loadFromFile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("loadFromFile() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_mergeProperties(t *testing.T) {
+	type args struct {
+		config    Properties
+		apicurito Properties
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *Properties
+		wantErr bool
+	}{
+		{
+			"When leaving Image in the CR empty, the default value from config should be taken",
+			args{config: Properties{Image: "apicurito/from-config"}, apicurito: Properties{}},
+			&Properties{"apicurito/from-config"},
+			false,
+		},
+		{
+			"When Image is present in the CR, the default value should be overwritten by the value from CR",
+			args{config: Properties{Image: "apicurito/from-config"}, apicurito: Properties{Image: "apicurito/from-cr"}},
+			&Properties{"apicurito/from-cr"},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mergeProperties(tt.args.config, tt.args.apicurito)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("mergeProperties() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("mergeProperties() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
With this PR `Spec.Image` is reintroduced as a parameter to Apicurito. If specified, `Spec.Image` will replace the default value from configuration file.

Other changes:
 - Reformat files
 - Change *apicuritosv1alpha* for *v1alpha* to simplify name conventions