### PR TITLE
apicurio-registry operator CI pipelines

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+cd apicurio-registry
+
+VERSION=$(sed -n 's/^.*Version.*=.*"\([0-9\.]*\)".*$/\1/p' ./version/version.go)
+if [ -z "$VERSION" ]
+then
+    echo "Could not read project version."
+    exit 1
+fi
+
+OPERATOR_IMAGE_NAME="${IMAGE_REGISTRY}/${IMAGE_REGISTRY_ORG}/apicurio-registry-operator"
+OPERATOR_IMAGE="${OPERATOR_IMAGE_NAME}:${VERSION}"
+
+operator-sdk generate k8s
+operator-sdk generate openapi
+operator-sdk build "${OPERATOR_IMAGE}"
+docker tag "${OPERATOR_IMAGE}" "${OPERATOR_IMAGE_NAME}:${TAG}"
+
+if [[ -v PUSH ]]
+then
+    echo "Logging in to image registry and pushing image"
+    docker login -u "${REGISTRY_USER}" -p "${REGISTRY_PASS}" "${IMAGE_REGISTRY}"
+
+    docker push "${OPERATOR_IMAGE}"
+    docker push "${OPERATOR_IMAGE_NAME}:${TAG}"
+fi
+

--- a/.github/scripts/install_dep.sh
+++ b/.github/scripts/install_dep.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+echo "Update archives"
+
+sudo add-apt-repository ppa:longsleep/golang-backports
+sudo apt-get update
+
+echo "Install golang"
+sudo apt-get install golang-1.13
+export GO111MODULE='on'
+
+echo "Install operator sdk"
+curl -fsSL https://github.com/operator-framework/operator-sdk/releases/download/v0.17.0/operator-sdk-v0.17.0-x86_64-linux-gnu > operator-sdk
+chmod +x operator-sdk
+sudo mv operator-sdk /usr/local/bin/operator-sdk
+
+echo "Clean cache"
+sudo apt-get clean
+
+#Docker installation from google default repositories
+sudo apt-get -y update
+
+sudo apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+sudo mkdir -p /mnt/docker
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+
+sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+
+sudo apt-get -y update
+sudo apt-get install docker-ce docker-ce-cli containerd.io

--- a/.github/scripts/install_dep.sh
+++ b/.github/scripts/install_dep.sh
@@ -1,13 +1,7 @@
 #!/bin/bash
 set -e
 
-echo "Update archives"
-
-sudo add-apt-repository ppa:longsleep/golang-backports
-sudo apt-get update
-
-echo "Install golang"
-sudo apt-get install golang-1.13
+echo "Set up golang"
 export GO111MODULE='on'
 
 echo "Install operator sdk"
@@ -17,18 +11,3 @@ sudo mv operator-sdk /usr/local/bin/operator-sdk
 
 echo "Clean cache"
 sudo apt-get clean
-
-#Docker installation from google default repositories
-sudo apt-get -y update
-
-sudo apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
-sudo mkdir -p /mnt/docker
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-
-sudo add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-   $(lsb_release -cs) \
-   stable"
-
-sudo apt-get -y update
-sudo apt-get install docker-ce docker-ce-cli containerd.io

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -1,0 +1,28 @@
+name: Apicurio-registry operator master build
+on:
+  push:
+    branches:
+      - master
+
+env:
+  IMAGE_REGISTRY: docker.io
+  IMAGE_REGISTRY_ORG: apicurio
+  TAG: latest
+  PUSH: true
+
+jobs:
+  master:
+    name: Build operator
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Install dependencies
+        run: ./.github/scripts/install_dep.sh
+
+      - name: build and push operator image
+        id: build
+        run: |
+          export REGISTRY_USER=${{ secrets.REGISTRY_USER }}
+          export REGISTRY_PASS=${{ secrets.REGISTRY_PASS }}
+          ./.github/scripts/build.sh 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,23 @@
+name: Pull request build
+
+on: [pull_request]
+
+env:
+  IMAGE_REGISTRY: docker.io
+  IMAGE_REGISTRY_ORG: apicurio
+  TAG: latest
+
+jobs:
+  pr:
+    name: Build operator
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Install dependencies
+        run: ./.github/scripts/install_dep.sh
+
+      - name: build operator image
+        id: build
+        run: |
+          ./.github/scripts/build.sh 


### PR DESCRIPTION
This is a draft version of what could be the CI pipelines in GH actions for apicurio-registry operator.
Requirements to get this working properly:
- create image `apicurio-registry-operator` in docker hub for apicurio org.
- set up secrets `REGISTRY_USER` and `REGISTRY_PASS` with credentials of an account with  access to docker hub `apicurio-registry-operator` repository.


One big downside is that this repo contains sources for two different operators and with this scripts apicurio-registry operator will be built if a PR only contains changes for apicurito operator. One solution to this is to split this repo in two separated repos.