### PR TITLE
chore: generate csv files also using the operator binary

### DIFF
--- a/apicurito/deploy/crds/apicur.io_apicuritoes_crd.yaml
+++ b/apicurito/deploy/crds/apicur.io_apicuritoes_crd.yaml
@@ -1,0 +1,58 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: apicuritoes.apicur.io
+spec:
+  group: apicur.io
+  names:
+    kind: Apicurito
+    listKind: ApicuritoList
+    plural: apicuritoes
+    singular: apicurito
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: Apicurito is the Schema for the apicuritos API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ApicuritoSpec defines the desired state of Apicurito
+          properties:
+            size:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                Important: Run "operator-sdk generate k8s" to regenerate code after
+                modifying this file Add custom validation using kubebuilder tags:
+                https://book.kubebuilder.io/beyond_basics/generating_crd.html'
+              format: int32
+              type: integer
+          required:
+          - size
+          type: object
+        status:
+          description: ApicuritoStatus defines the observed state of Apicurito
+          properties:
+            nodes:
+              description: Nodes are the names of the apicurito pods
+              items:
+                type: string
+              type: array
+          required:
+          - nodes
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/apicurito/deploy/manifests/0.2.0/apicuritooperator.v0.2.0.clusterserviceversion.yaml
+++ b/apicurito/deploy/manifests/0.2.0/apicuritooperator.v0.2.0.clusterserviceversion.yaml
@@ -17,8 +17,8 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Integration & Delivery
     certified: "false"
-    containerImage: registry.redhat.io/fuse7-tech-preview/fuse-apicurito-operator@sha256:774527bfca019d86eec9c84f8b78f472ca46c953c1d1d55b6d9dac751452d19f
-    createdAt: "2020-04-01 10:31:09"
+    containerImage: registry.redhat.io/fuse7-tech-preview/fuse-apicurito-operator:1.6
+    createdAt: "2020-05-19 11:50:20"
     description: Manages the installation and upgrades of apicurito, a small/minimal
       version of Apicurio
     repository: https://github.com/Apicurio/apicurio-operators/tree/master/apicurito
@@ -106,23 +106,11 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: apicurito-operator
-                image: registry.redhat.io/fuse7-tech-preview/fuse-apicurito-operator@sha256:774527bfca019d86eec9c84f8b78f472ca46c953c1d1d55b6d9dac751452d19f
+                image: registry.redhat.io/fuse7-tech-preview/fuse-apicurito-operator:1.6
                 imagePullPolicy: Always
                 name: apicurito-operator
                 resources: {}
-              serviceAccountName: apicurito-operator
-      clusterPermissions:
-        - rules:
-            - apiGroups:
-                - console.openshift.io
-              resources:
-                - consoleyamlsamples
-              verbs:
-                - get
-                - create
-                - update
-                - delete
-          serviceAccountName: apicurito-operator
+              serviceAccountName: apicurito
       permissions:
       - rules:
         - apiGroups:
@@ -177,7 +165,7 @@ spec:
           - create
           - update
           - watch
-        serviceAccountName: apicurito-operator
+        serviceAccountName: apicurito
     strategy: deployment
   installModes:
   - supported: true
@@ -206,10 +194,10 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-  - image: registry.redhat.io/fuse7-tech-preview/fuse-apicurito-operator@sha256:774527bfca019d86eec9c84f8b78f472ca46c953c1d1d55b6d9dac751452d19f
-    name: fuse-apicurito-operator
-  - image: registry.redhat.io/fuse7/fuse-apicurito@sha256:1177f9ee841f95f40ea0b0de76f28c3a7b01ebef5ab335674f24bb5c17f88431
-    name: fuse-apicurito
+    - image: registry.redhat.io/fuse7-tech-preview/fuse-apicurito-operator:1.6
+      name: fuse-apicurito-operator
+    - image: registry.redhat.io/fuse7/fuse-apicurito:1.6
+      name: fuse-apicurito
   replaces: apicuritooperator.v0.1.0
   selector:
     matchLabels:

--- a/apicurito/deploy/operator.yaml
+++ b/apicurito/deploy/operator.yaml
@@ -6,20 +6,17 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: apicurito-operator
       app: apicurito
+      name: apicurito-operator
+  strategy: {}
   template:
     metadata:
       labels:
-        name: apicurito-operator
         app: apicurito
+        name: apicurito-operator
     spec:
-      serviceAccountName: apicurito
       containers:
-        - name: apicurito-operator
-          image: apicurio/apicurito-operator:v0.1
-          imagePullPolicy: Always
-          env:
+        - env:
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -29,4 +26,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: "apicurito-operator"
+              value: apicurito-operator
+          image: registry.redhat.io/fuse7-tech-preview/fuse-apicurito-operator:1.6
+          imagePullPolicy: Always
+          name: apicurito-operator
+          resources: {}
+      serviceAccountName: apicurito

--- a/apicurito/deploy/role.yaml
+++ b/apicurito/deploy/role.yaml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
   name: apicurito
 rules:
 - apiGroups:
@@ -47,7 +46,12 @@ rules:
   verbs:
   - '*'
 - apiGroups:
-  - route.openshift.io
+    - route.openshift.io
   resources:
-  - routes
-  verbs: [ get, list, create, update, watch ]
+    - routes
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - watch

--- a/apicurito/go.sum
+++ b/apicurito/go.sum
@@ -791,6 +791,7 @@ github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190125151539-1
 github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190605231540-b8a4faf68e36/go.mod h1:HKV3ZB9aOUxRyfM53shoBRtIMP4lg8QRmkW+dmZy+kI=
 github.com/operator-framework/operator-lifecycle-manager v0.0.0-20191115003340-16619cd27fa5 h1:rjaihxY50c5C+kbQIK4s36R8zxByATYrgRbua4eiG6o=
 github.com/operator-framework/operator-lifecycle-manager v0.0.0-20191115003340-16619cd27fa5/go.mod h1:zL34MNy92LPutBH5gQK+gGhtgTUlZZX03I2G12vWHF4=
+github.com/operator-framework/operator-lifecycle-manager v3.11.0+incompatible h1:Po8C8RVLRWq7pNQ5pKonM9CXpC/osoBWbmsuf+HJnSI=
 github.com/operator-framework/operator-marketplace v0.0.0-20190216021216-57300a3ef3ba/go.mod h1:msZSL8pXwzQjB+hU+awVrZQw94IwJi3sNZVD3NoESIs=
 github.com/operator-framework/operator-registry v1.0.1/go.mod h1:1xEdZjjUg2hPEd52LG3YQ0jtwiwEGdm98S1TH5P4RAA=
 github.com/operator-framework/operator-registry v1.0.4/go.mod h1:hve6YwcjM2nGVlscLtNsp9sIIBkNZo6jlJgzWw7vP9s=

--- a/apicurito/pkg/apis/apicur/v1alpha1/zz_generated.openapi.go
+++ b/apicurito/pkg/apis/apicur/v1alpha1/zz_generated.openapi.go
@@ -5,15 +5,15 @@
 package v1alpha1
 
 import (
-	spec "github.com/go-openapi/spec"
-	common "k8s.io/kube-openapi/pkg/common"
+	"github.com/go-openapi/spec"
+	"k8s.io/kube-openapi/pkg/common"
 )
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"./pkg/apis/apicur/v1alpha1.Apicurito":       schema_pkg_apis_apicur_v1alpha1_Apicurito(ref),
-		"./pkg/apis/apicur/v1alpha1.ApicuritoSpec":   schema_pkg_apis_apicur_v1alpha1_ApicuritoSpec(ref),
-		"./pkg/apis/apicur/v1alpha1.ApicuritoStatus": schema_pkg_apis_apicur_v1alpha1_ApicuritoStatus(ref),
+		"github.com/apicurio/apicurio-operators/apicurito/pkg/apis/apicur/v1alpha1.Apicurito":       schema_pkg_apis_apicur_v1alpha1_Apicurito(ref),
+		"github.com/apicurio/apicurio-operators/apicurito/pkg/apis/apicur/v1alpha1.ApicuritoSpec":   schema_pkg_apis_apicur_v1alpha1_ApicuritoSpec(ref),
+		"github.com/apicurio/apicurio-operators/apicurito/pkg/apis/apicur/v1alpha1.ApicuritoStatus": schema_pkg_apis_apicur_v1alpha1_ApicuritoStatus(ref),
 	}
 }
 
@@ -45,19 +45,19 @@ func schema_pkg_apis_apicur_v1alpha1_Apicurito(ref common.ReferenceCallback) com
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./pkg/apis/apicur/v1alpha1.ApicuritoSpec"),
+							Ref: ref("github.com/apicurio/apicurio-operators/apicurito/pkg/apis/apicur/v1alpha1.ApicuritoSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./pkg/apis/apicur/v1alpha1.ApicuritoStatus"),
+							Ref: ref("github.com/apicurio/apicurio-operators/apicurito/pkg/apis/apicur/v1alpha1.ApicuritoStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/apicur/v1alpha1.ApicuritoSpec", "./pkg/apis/apicur/v1alpha1.ApicuritoStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/apicurio/apicurio-operators/apicurito/pkg/apis/apicur/v1alpha1.ApicuritoSpec", "github.com/apicurio/apicurio-operators/apicurito/pkg/apis/apicur/v1alpha1.ApicuritoStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 

--- a/apicurito/pkg/cmd/olm.go
+++ b/apicurito/pkg/cmd/olm.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"flag"
+
+	"github.com/apicurio/apicurio-operators/apicurito/tools/run"
+	"github.com/operator-framework/operator-sdk/pkg/log/zap"
+	"github.com/spf13/cobra"
+)
+
+type csv struct {
+	*Options
+}
+
+func newOlmCommand(parent *Options) *cobra.Command {
+	options := csv{Options: parent}
+	cmd := cobra.Command{
+		Use:   "olm",
+		Short: "generates bundle files for OLM installation",
+		Run: func(_ *cobra.Command, _ []string) {
+			exitOnError(options.run())
+		},
+	}
+
+	cmd.PersistentFlags().AddFlagSet(zap.FlagSet())
+	cmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+
+	return &cmd
+}
+
+func (c csv) run() error {
+	run.Run()
+	return nil
+}

--- a/apicurito/pkg/cmd/public.go
+++ b/apicurito/pkg/cmd/public.go
@@ -53,6 +53,7 @@ func NewApicuritoCommand(ctx context.Context) (*cobra.Command, error) {
 	cmd.PersistentFlags().AddGoFlag(&f)
 
 	cmd.AddCommand(newRunCommand(&options))
+	cmd.AddCommand(newOlmCommand(&options))
 	return &cmd, nil
 }
 

--- a/apicurito/scripts/go-csv.sh
+++ b/apicurito/scripts/go-csv.sh
@@ -2,4 +2,4 @@
 
 
 
-go run ./tools/csv-gen/csv-gen.go
+go run ./tools/csv-gen/main.go

--- a/apicurito/tools/components/components.go
+++ b/apicurito/tools/components/components.go
@@ -1,12 +1,13 @@
 package components
 
 import (
+	"strings"
+
 	monv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 )
 
 func GetDeployment(operatorName, repository, context, imageName, tag, imagePullPolicy string) *appsv1.Deployment {
@@ -36,7 +37,7 @@ func GetDeployment(operatorName, repository, context, imageName, tag, imagePullP
 					},
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: operatorName,
+					ServiceAccountName: "apicurito",
 					Containers: []corev1.Container{
 						{
 							Name:            operatorName,
@@ -84,7 +85,7 @@ func GetRole(operatorName string) *rbacv1.Role {
 			Kind:       "Role",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: operatorName,
+			Name: "apicurito",
 		},
 		Rules: []rbacv1.PolicyRule{
 			{

--- a/apicurito/tools/csv-gen/main.go
+++ b/apicurito/tools/csv-gen/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/apicurio/apicurio-operators/apicurito/tools/run"
+
+func main() {
+	run.Run()
+}

--- a/apicurito/tools/run/run.go
+++ b/apicurito/tools/run/run.go
@@ -1,13 +1,14 @@
-package main
+package run
 
 import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"net/http"
+
 	api "github.com/apicurio/apicurio-operators/apicurito/pkg/apis/apicur/v1alpha1"
 	config "github.com/apicurio/apicurio-operators/apicurito/pkg/configuration"
 	"github.com/heroku/docker-registry-client/registry"
-	"net/http"
 
 	"github.com/apicurio/apicurio-operators/apicurito/tools/components"
 	"github.com/apicurio/apicurio-operators/apicurito/tools/constants"
@@ -50,7 +51,7 @@ var (
 	}
 )
 
-func main() {
+func Run() {
 
 	imageShaMap := map[string]string{}
 


### PR DESCRIPTION
By running `./apicurito-operator olm`, the image bundle files needed for OLM installation are generated under /deploy/manifests/$version

chore: fix role and service account name